### PR TITLE
[Feat] 카테고리 없는 글을 위한 기타 탭 추가

### DIFF
--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 import PostSortableList from '@/components/admin/PostSortableList';
+import { UNASSIGNED_CATEGORY_LABEL } from '@/constants/category';
 import { getCategories } from '@/lib/categories';
 import { createClient } from '@/lib/supabase/server';
 import type { Database } from '@/types/database';
@@ -28,7 +29,7 @@ export default async function AdminPostsPage() {
     id: post.id,
     title: post.title,
     category: post.category,
-    categoryLabel: categoryLabel[post.category] ?? '미할당',
+    categoryLabel: categoryLabel[post.category] ?? UNASSIGNED_CATEGORY_LABEL,
     published: post.published,
     created_at: post.created_at,
   }));

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { OTHER_CATEGORY_LABEL } from '@/constants/category';
 import { getCategories } from '@/lib/categories';
 import { getPostBySlug } from '@/lib/posts';
 
@@ -68,7 +69,7 @@ export default async function BlogPostPage({
 
       <header className="mt-8">
         <span className="text-sm text-accent">
-          {categoryLabel[post.category] ?? '기타'}
+          {categoryLabel[post.category] ?? OTHER_CATEGORY_LABEL}
         </span>
         <h1 className="mt-2 text-3xl font-bold sm:text-4xl">{post.title}</h1>
         <p className="mt-3 text-sm text-muted">{date}</p>

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -4,6 +4,10 @@ import { useState } from 'react';
 
 import BlogCard, { type GridSize } from '@/components/BlogCard';
 import CategoryTabs from '@/components/CategoryTabs';
+import {
+  OTHER_CATEGORY_LABEL,
+  OTHER_CATEGORY_SLUG,
+} from '@/constants/category';
 import type { PostSummary } from '@/lib/posts';
 
 type ViewMode = 'grid' | 'list';
@@ -45,7 +49,10 @@ export default function BlogSection({
   );
   const tabCategories =
     orphanPosts.length > 0
-      ? [...categories, { slug: '__other__', name: '기타' }]
+      ? [
+          ...categories,
+          { slug: OTHER_CATEGORY_SLUG, name: OTHER_CATEGORY_LABEL },
+        ]
       : categories;
 
   const [category, setCategory] = useState<string | null>(
@@ -55,7 +62,7 @@ export default function BlogSection({
   const [gridSize, setGridSize] = useState<GridSize>(defaultGridSize);
 
   const filtered =
-    category === '__other__'
+    category === OTHER_CATEGORY_SLUG
       ? orphanPosts
       : category
         ? posts.filter((p) => p.category === category)

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -1,0 +1,3 @@
+export const OTHER_CATEGORY_SLUG = '__other__';
+export const OTHER_CATEGORY_LABEL = '기타';
+export const UNASSIGNED_CATEGORY_LABEL = '미할당';


### PR DESCRIPTION
## 요약

고아 포스트(카테고리가 삭제되거나 지정되지 않은 글)가 어느 탭에도 표시되지 않는 문제를 해결한다.

## 배경

- 카테고리가 삭제된 경우 해당 카테고리의 글들이 어느 탭에도 표시되지 않음
- 카테고리가 없는 글을 위한 폴백 처리가 필요함

## 구현 내용

- `BlogSection`에서 `categories` 배열에 존재하지 않는 slug를 가진 포스트(고아 포스트) 감지
- 고아 포스트가 1개 이상일 때만 `__other__` slug로 "기타" 탭을 `tabCategories` 마지막에 추가
- 필터링 로직에서 `__other__` 선택 시 고아 포스트만 반환하도록 분기 처리
- DB 변경 없이 프론트엔드만으로 처리

## 테스트

- 모든 포스트가 유효한 카테고리를 가질 때 기타 탭 미표시 확인
- 포스트의 category를 존재하지 않는 slug로 변경 시 기타 탭 표시 확인
- 기타 탭 클릭 시 해당 포스트만 필터링되어 표시 확인
- 기존 카테고리 탭 동작에 영향 없음 확인

## 관련 이슈

Closes #5